### PR TITLE
Adding platform awareness for keyboard padding

### DIFF
--- a/lib/ChatBot.js
+++ b/lib/ChatBot.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Random from 'random-id';
-import { Dimensions, TextInput, ScrollView } from 'react-native';
+import { Dimensions, TextInput, ScrollView, Platform } from 'react-native';
 import { CustomStep, OptionsStep, TextStep } from './steps/steps';
 import schema from './schemas/schema';
 import ChatBotContainer from './ChatBotContainer';
@@ -491,6 +491,7 @@ class ChatBot extends Component {
 
     const textInputStyle = Object.assign({}, styles.input, inputStyle);
     const scrollViewStyle = Object.assign({}, styles.content, contentStyle);
+    const platformBehavior = Platform.OS === 'ios' ? 'padding' : 'height';
 
     return (
       <ChatBotContainer
@@ -505,7 +506,7 @@ class ChatBot extends Component {
         >
           {_.map(renderedSteps, this.renderStep)}
         </ScrollView>
-        <InputView behavior="padding">
+        <InputView behavior={platformBehavior}>
           <Footer
             className="rsc-footer"
             style={footerStyle}


### PR DESCRIPTION
On android devices (and/or emulator) and when the input has focus, the KeyboardAvoindingView creates a padding hiding most of the content of the chat.

So I've altered the behavior for KeyboardAvoidingView on android devices, preserving original prop for ios, making it platform aware.

On android the final result is not entirely perfect, because the keyboard rise above content, so the user should swipe up to see the most recent conversations.

Although not 100%, the user swiping up and the appearance of the resulting input is more acceptable for android users.