### PR TITLE
Moves default backgroundColor to contentStyle

### DIFF
--- a/lib/ChatBot.js
+++ b/lib/ChatBot.js
@@ -592,7 +592,9 @@ ChatBot.defaultProps = {
   customDelay: 1000,
   customLoadingColor: '#4a4a4a',
   className: '',
-  footerStyle: {},
+  footerStyle: {
+    backgroundColor: '#f5f8fb',
+  },
   handleEnd: undefined,
   hideBotAvatar: false,
   hideUserAvatar: false,

--- a/lib/ChatBot.js
+++ b/lib/ChatBot.js
@@ -585,7 +585,9 @@ ChatBot.defaultProps = {
   botDelay: 1000,
   botFontColor: '#fff',
   bubbleStyle: {},
-  contentStyle: {},
+  contentStyle: {
+    backgroundColor: '#f5f8fb',
+  },
   customStyle: {},
   customDelay: 1000,
   customLoadingColor: '#4a4a4a',

--- a/lib/ChatBotContainer.js
+++ b/lib/ChatBotContainer.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components/native';
 
 const ChatBotContainer = styled.View`
-  background-color: #f5f8fb;
   overflow: hidden;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
I wanted to set a backgroundColor with with an alpha level on contentStyle to make the background transparent/semi-transparent, but the default background color prevents this.  This should fix it.