### PR TITLE
adding keyboardVerticalOffset as property of chatbot.js

### DIFF
--- a/lib/ChatBot.js
+++ b/lib/ChatBot.js
@@ -470,6 +470,7 @@ class ChatBot extends Component {
       placeholder,
       style,
       submitButtonStyle,
+      keyboardVerticalOffset
     } = this.props;
 
     const styles = {
@@ -506,7 +507,7 @@ class ChatBot extends Component {
         >
           {_.map(renderedSteps, this.renderStep)}
         </ScrollView>
-        <InputView behavior={platformBehavior}>
+        <InputView behavior={platformBehavior} keyboardVerticalOffset={keyboardVerticalOffset}>
           <Footer
             className="rsc-footer"
             style={footerStyle}


### PR DESCRIPTION
When I put a header in my component, in iOS the input component was hidden below the keyboard. So I add this keyboardVerticalOffset in props to edit the height and fixing this trouble.