### PR TITLE
Allow to use text or components on the submit button

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ const steps = [
 | `steps` | `PropTypes.array`  | | The chatbot steps to display |
 | `style` | `PropTypes.object`  | | The style object to use to override the submit button element |
 | `submitButtonStyle` | `PropTypes.object`  | | The style object to use to override the button element |
+| `submitButtonContent` | `PropTypes.string` or `PropTypes.element` | `SEND`| The string or object to use to override the button content |
 | `userAvatar` | `PropTypes.string`  | `img` | User image source |
 | `userBubbleColor` | `PropTypes.string`  | `#fff` | User bubble color |
 | `userDelay` | `PropTypes.number`  | `1000` | The delay time of user messages |

--- a/lib/ChatBot.js
+++ b/lib/ChatBot.js
@@ -478,6 +478,7 @@ class ChatBot extends Component {
       placeholder,
       style,
       submitButtonStyle,
+      submitButtonContent,
       scrollViewProps,
     } = this.props;
 
@@ -556,7 +557,7 @@ class ChatBot extends Component {
                 invalid={inputInvalid}
                 fontColor={botFontColor}
               >
-                SEND
+                {submitButtonContent}
               </ButtonText>
             </Button>
           </Footer>
@@ -591,6 +592,7 @@ ChatBot.propTypes = {
   steps: PropTypes.array.isRequired,
   style: PropTypes.object,
   submitButtonStyle: PropTypes.object,
+  submitButtonContent: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   userAvatar: PropTypes.string,
   userBubbleColor: PropTypes.string,
   userDelay: PropTypes.number,
@@ -621,6 +623,7 @@ ChatBot.defaultProps = {
   headerComponent: undefined,
   style: {},
   submitButtonStyle: {},
+  submitButtonContent: 'SEND',
   userBubbleColor: '#fff',
   userDelay: 1000,
   userFontColor: '#4a4a4a',


### PR DESCRIPTION
Example using a Portuguese text:
```javascript
import React from "react";
import ChatBot from "react-native-chatbot";

import steps from "./steps";

const ChatBotTest = () => (
  <ChatBot 
    steps={steps} 
    submitButtonContent="Enviar" 
  />
);

export default ChatBotTest;
```

Example using the Image component:
```javascript
import React from "react";
import { Image } from "react-native";

import ChatBot from "react-native-chatbot";

import steps from "./steps";

const ChatBotTest = () => (
  <ChatBot
    steps={steps}
    submitButtonContent={
      <Image source={require("../assets/images/send.png")} />
    }
  />
);

export default ChatBotTest;
```

Example using the Vector Icons package:
```javascript
import React from "react";
import ChatBot from "react-native-chatbot";
import Icon from 'react-native-vector-icons/FontAwesome';

import steps from "./steps";

const ChatBotTest = () => (
  <ChatBot
    steps={steps}
    submitButtonContent={
      <Icon name="send" size={20} color="#FFFFFF" />
    }
  />
);

export default ChatBotTest;
```