### PR TITLE
Update ChatBot.js deprecated componentWillMount()

### DIFF
--- a/lib/ChatBot.js
+++ b/lib/ChatBot.js
@@ -46,7 +46,7 @@ class ChatBot extends Component {
     this.keyboardDidHideListener = Keyboard.addListener('keyboardDidHide', this.setScrollViewScrollToEnd);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const {
       botDelay,
       botAvatar,


### PR DESCRIPTION
Update the deprecated componentWillMount lifecycle method to the componentDidMount lifecycle method to fix the following issue issue:

> Warning: componentWillMount is deprecated and will be removed in the next major version. Use componentDidMount instead. As a temporary workaround, you can rename to UNSAFE_componentWillMount.